### PR TITLE
Silence various compiler warnings

### DIFF
--- a/source/Instance/InstanceManager.cpp
+++ b/source/Instance/InstanceManager.cpp
@@ -402,7 +402,7 @@ void InstanceManager::Render()
 				glVertexAttribPointer(in_model_matrix + i,		// Location
 					4, GL_FLOAT, GL_FALSE,	// vec4
 					4*16,						// Stride
-					(void *)(16 * i));		// Start offset
+					reinterpret_cast<void *>(16 * i));		// Start offset
 
 				glEnableVertexAttribArray(in_model_matrix + i);
 				glVertexAttribDivisor(in_model_matrix + i, 1);

--- a/source/Particles/BlockParticleManager.cpp
+++ b/source/Particles/BlockParticleManager.cpp
@@ -1070,7 +1070,7 @@ void BlockParticleManager::RenderInstanced(bool noWorldOffset)
 			glVertexAttribPointer(in_model_matrix + i,		// Location
 				4, GL_FLOAT, GL_FALSE,	// vec4
 				4 * 16,						// Stride
-				(void *)(16 * i));		// Start offset
+				reinterpret_cast<void *>(16 * i));		// Start offset
 
 			glEnableVertexAttribArray(in_model_matrix + i);
 			glVertexAttribDivisor(in_model_matrix + i, 1);

--- a/source/Particles/BlockParticleManager.cpp
+++ b/source/Particles/BlockParticleManager.cpp
@@ -1182,7 +1182,7 @@ void BlockParticleManager::RenderBlockParticle(BlockParticle* pBlockParticle, bo
 		m_pRenderer->PushMatrix();
 			m_pRenderer->SetPrimativeMode(PM_QUADS);
 			//m_pRenderer->EnableTransparency(BF_SRC_ALPHA, BF_ONE_MINUS_SRC_ALPHA);
-			m_pRenderer->RenderFromArray(VT_POSITION_NORMAL_COLOUR, m_blockMaterialID, NULL, 24, 24, 0, &m_vertexBuffer, NULL, NULL);
+			m_pRenderer->RenderFromArray(VT_POSITION_NORMAL_COLOUR, m_blockMaterialID, 0, 24, 24, 0, &m_vertexBuffer, NULL, NULL);
 			//m_pRenderer->DisableTransparency();
 		m_pRenderer->PopMatrix();
 

--- a/source/Quests/Quest.cpp
+++ b/source/Quests/Quest.cpp
@@ -199,7 +199,7 @@ void Quest::ExportQuest()
 			}
 			else
 			{
-				exportFile << NULL << "|0|";
+				exportFile << 0 << "|0|";
 			}
 
 			if(m_vpObjectives[i]->m_placementItem)

--- a/source/Renderer/Renderer.cpp
+++ b/source/Renderer/Renderer.cpp
@@ -14,7 +14,7 @@
 #include "Renderer.h"
 
 // GL ERROR CHECK
-int CheckGLErrors(char *file, int line)
+int CheckGLErrors(const char *file, int line)
 {
 	GLenum glErr;
 	int    retCode = 0;
@@ -1014,7 +1014,7 @@ void Renderer::DrawSphericalSector(float lRadius, float angle, int lSectors, int
 }
 
 // Text rendering
-bool Renderer::CreateFreeTypeFont(char *fontName, int fontSize, unsigned int *pID, bool noAutoHint)
+bool Renderer::CreateFreeTypeFont(const char *fontName, int fontSize, unsigned int *pID, bool noAutoHint)
 {
 	FreeTypeFont* font = new FreeTypeFont();
 
@@ -1028,7 +1028,7 @@ bool Renderer::CreateFreeTypeFont(char *fontName, int fontSize, unsigned int *pI
 	return true;
 }
 
-bool Renderer::RenderFreeTypeText(unsigned int fontID, float x, float y, float z, Colour colour, float scale, char *inText, ...)
+bool Renderer::RenderFreeTypeText(unsigned int fontID, float x, float y, float z, Colour colour, float scale, const char *inText, ...)
 {
 	char		outText[8192];
 	va_list		ap;  // Pointer to list of arguments
@@ -1059,7 +1059,7 @@ bool Renderer::RenderFreeTypeText(unsigned int fontID, float x, float y, float z
 	return true;
 }
 
-int Renderer::GetFreeTypeTextWidth(unsigned int fontID, char *inText, ...)
+int Renderer::GetFreeTypeTextWidth(unsigned int fontID, const char *inText, ...)
 {
 	char outText[8192];
 	va_list ap;
@@ -1075,7 +1075,7 @@ int Renderer::GetFreeTypeTextWidth(unsigned int fontID, char *inText, ...)
 	return m_freetypeFonts[fontID]->GetTextWidth(outText);
 }
 
-int Renderer::GetFreeTypeTextHeight(unsigned int fontID, char *inText, ...)
+int Renderer::GetFreeTypeTextHeight(unsigned int fontID, const char *inText, ...)
 {
 	return m_freetypeFonts[fontID]->GetCharHeight('a');
 }
@@ -2552,7 +2552,7 @@ unsigned int Renderer::GetDepthTextureFromFrameBuffer(unsigned int frameBufferId
 }
 
 // Shaders
-bool Renderer::LoadGLSLShader(char* vertexFile, char* fragmentFile, unsigned int *pID)
+bool Renderer::LoadGLSLShader(const char* vertexFile, const char* fragmentFile, unsigned int *pID)
 {
 	glShader* lpShader = NULL;
 

--- a/source/Renderer/Renderer.h
+++ b/source/Renderer/Renderer.h
@@ -268,10 +268,10 @@ public:
 	void DrawSphericalSector(float lRadius, float angle, int lSectors, int lPoints);
 
 	// Text rendering
-	bool CreateFreeTypeFont(char *fontName, int fontSize, unsigned int *pID, bool noAutoHint = false);
-	bool RenderFreeTypeText(unsigned int fontID, float x, float y, float z, Colour colour, float scale, char *inText, ...);
-	int GetFreeTypeTextWidth(unsigned int fontID, char *inText, ...);
-	int GetFreeTypeTextHeight(unsigned int fontID, char *inText, ...);
+	bool CreateFreeTypeFont(const char *fontName, int fontSize, unsigned int *pID, bool noAutoHint = false);
+	bool RenderFreeTypeText(unsigned int fontID, float x, float y, float z, Colour colour, float scale, const char *inText, ...);
+	int GetFreeTypeTextWidth(unsigned int fontID, const char *inText, ...);
+	int GetFreeTypeTextHeight(unsigned int fontID, const char *inText, ...);
 	int GetFreeTypeTextAscent(unsigned int fontID);
 	int GetFreeTypeTextDescent(unsigned int fontID);
 
@@ -368,7 +368,7 @@ public:
 	unsigned int GetDepthTextureFromFrameBuffer(unsigned int frameBufferId);
 
 	// Shaders
-	bool LoadGLSLShader(char* vertexFile, char* fragmentFile, unsigned int *pID);
+	bool LoadGLSLShader(const char* vertexFile, const char* fragmentFile, unsigned int *pID);
 	void BeginGLSLShader(unsigned int shaderID);
 	void EndGLSLShader(unsigned int shaderID);
 	glShader* GetShader(unsigned int shaderID);

--- a/source/Renderer/glsl.cpp
+++ b/source/Renderer/glsl.cpp
@@ -68,7 +68,7 @@ Initialization:
 //{
 //-----------------------------------------------------------------------------
 // Error, Warning and Info Strings
-char* aGLSLStrings[] = {
+const char* aGLSLStrings[] = {
         "[e00] GLSL is not available!",
         "[e01] Not a valid program object!",
         "[e02] Not a valid object!",
@@ -81,7 +81,7 @@ char* aGLSLStrings[] = {
 //-----------------------------------------------------------------------------      
  
 // GL ERROR CHECK
-   int CheckGLError(char *file, int line)
+   int CheckGLError(const char *file, int line)
    {
 	   GLenum glErr;
 	   int    retCode = 0;
@@ -363,7 +363,7 @@ return false;
 //----------------------------------------------------------------------------- 
 // Compiler Log: Ausgabe der Compiler Meldungen in String
 
-char* glShader::getLinkerLog(void)
+const char* glShader::getLinkerLog(void)
 {    
 if (!useGLSL) return aGLSLStrings[0];
  
@@ -426,7 +426,7 @@ if (!_noshader) return;
 
 //----------------------------------------------------------------------------- 
 
-bool glShader::setUniform1f(GLcharARB* varname, GLfloat v0, GLint index)
+bool glShader::setUniform1f(const GLcharARB* varname, GLfloat v0, GLint index)
 {
     if (!useGLSL) return false; // GLSL not available
     if (!_noshader) return true;
@@ -448,7 +448,7 @@ bool glShader::setUniform1f(GLcharARB* varname, GLfloat v0, GLint index)
 
 //----------------------------------------------------------------------------- 
 
-bool glShader::setUniform2f(GLcharARB* varname, GLfloat v0, GLfloat v1, GLint index)
+bool glShader::setUniform2f(const GLcharARB* varname, GLfloat v0, GLfloat v1, GLint index)
 {
    if (!useGLSL) return false; // GLSL not available
    if (!_noshader) return true;
@@ -469,7 +469,7 @@ bool glShader::setUniform2f(GLcharARB* varname, GLfloat v0, GLfloat v1, GLint in
 
 //----------------------------------------------------------------------------- 
 
-bool glShader::setUniform3f(GLcharARB* varname, GLfloat v0, GLfloat v1, GLfloat v2, GLint index)
+bool glShader::setUniform3f(const GLcharARB* varname, GLfloat v0, GLfloat v1, GLfloat v2, GLint index)
 {
     if (!useGLSL) return false; // GLSL not available
     if (!_noshader) return true;
@@ -490,7 +490,7 @@ bool glShader::setUniform3f(GLcharARB* varname, GLfloat v0, GLfloat v1, GLfloat 
 
 //----------------------------------------------------------------------------- 
 
-bool glShader::setUniform4f(GLcharARB* varname, GLfloat v0, GLfloat v1, GLfloat v2, GLfloat v3, GLint index)
+bool glShader::setUniform4f(const GLcharARB* varname, GLfloat v0, GLfloat v1, GLfloat v2, GLfloat v3, GLint index)
 {
     if (!useGLSL) return false; // GLSL not available
     if (!_noshader) return true;
@@ -511,7 +511,7 @@ bool glShader::setUniform4f(GLcharARB* varname, GLfloat v0, GLfloat v1, GLfloat 
 
 //----------------------------------------------------------------------------- 
 
-bool glShader::setUniform1i(GLcharARB* varname, GLint v0, GLint index)
+bool glShader::setUniform1i(const GLcharARB* varname, GLint v0, GLint index)
 { 
     if (!useGLSL) return false; // GLSL not available
     if (!_noshader) return true;
@@ -532,7 +532,7 @@ bool glShader::setUniform1i(GLcharARB* varname, GLint v0, GLint index)
 
 //-----------------------------------------------------------------------------
 
-bool glShader::setUniform2i(GLcharARB* varname, GLint v0, GLint v1, GLint index)
+bool glShader::setUniform2i(const GLcharARB* varname, GLint v0, GLint v1, GLint index)
 {
     if (!useGLSL) return false; // GLSL not available
     if (!_noshader) return true;
@@ -554,7 +554,7 @@ bool glShader::setUniform2i(GLcharARB* varname, GLint v0, GLint v1, GLint index)
 
 //----------------------------------------------------------------------------- 
 
-bool glShader::setUniform3i(GLcharARB* varname, GLint v0, GLint v1, GLint v2, GLint index)
+bool glShader::setUniform3i(const GLcharARB* varname, GLint v0, GLint v1, GLint v2, GLint index)
 {
     if (!useGLSL) return false; // GLSL not available
     if (!_noshader) return true;
@@ -575,7 +575,7 @@ bool glShader::setUniform3i(GLcharARB* varname, GLint v0, GLint v1, GLint v2, GL
 
 //-----------------------------------------------------------------------------
 
-bool glShader::setUniform4i(GLcharARB* varname, GLint v0, GLint v1, GLint v2, GLint v3, GLint index)
+bool glShader::setUniform4i(const GLcharARB* varname, GLint v0, GLint v1, GLint v2, GLint v3, GLint index)
 {
     if (!useGLSL) return false; // GLSL not available
     if (!_noshader) return true;
@@ -596,7 +596,7 @@ bool glShader::setUniform4i(GLcharARB* varname, GLint v0, GLint v1, GLint v2, GL
 //-----------------------------------------------------------------------------
 //----------------------------------------------------------------------------- 
 
-bool glShader::setUniform1ui(GLcharARB* varname, GLuint v0, GLint index)
+bool glShader::setUniform1ui(const GLcharARB* varname, GLuint v0, GLint index)
 { 
     if (!useGLSL) return false; // GLSL not available
     if (!bGPUShader4) return false;
@@ -618,7 +618,7 @@ bool glShader::setUniform1ui(GLcharARB* varname, GLuint v0, GLint index)
 
 //-----------------------------------------------------------------------------
 
-bool glShader::setUniform2ui(GLcharARB* varname, GLuint v0, GLuint v1, GLint index)
+bool glShader::setUniform2ui(const GLcharARB* varname, GLuint v0, GLuint v1, GLint index)
 {
     if (!useGLSL) return false; // GLSL not available
     if (!bGPUShader4) return false;
@@ -641,7 +641,7 @@ bool glShader::setUniform2ui(GLcharARB* varname, GLuint v0, GLuint v1, GLint ind
 
 //----------------------------------------------------------------------------- 
 
-bool glShader::setUniform3ui(GLcharARB* varname, GLuint v0, GLuint v1, GLuint v2, GLint index)
+bool glShader::setUniform3ui(const GLcharARB* varname, GLuint v0, GLuint v1, GLuint v2, GLint index)
 {
     if (!useGLSL) return false; // GLSL not available
     if (!bGPUShader4) return false;
@@ -663,349 +663,349 @@ bool glShader::setUniform3ui(GLcharARB* varname, GLuint v0, GLuint v1, GLuint v2
 
 //-----------------------------------------------------------------------------
 
-bool glShader::setUniform4ui(GLcharARB* varname, GLuint v0, GLuint v1, GLuint v2, GLuint v3, GLint index)
+bool glShader::setUniform4ui(const GLcharARB* varname, GLuint v0, GLuint v1, GLuint v2, GLuint v3, GLint index)
 {
     if (!useGLSL) return false; // GLSL not available
     if (!bGPUShader4) return false;
     if (!_noshader) return true;
-    
+
     GLint loc;
     if (varname)
        loc = GetUniformLocation(varname);
     else
        loc = index;
 
-    if (loc==-1) 
+    if (loc==-1)
        return false;  // can't find variable / invalid index
-    
+
     glUniform4uiEXT(loc, v0, v1, v2, v3);
 
     return true;
 }
 //-----------------------------------------------------------------------------
 
-bool glShader::setUniform1fv(GLcharARB* varname, GLsizei count, GLfloat *value, GLint index)
+bool glShader::setUniform1fv(const GLcharARB* varname, GLsizei count, GLfloat *value, GLint index)
 {
     if (!useGLSL) return false; // GLSL not available
     if (!_noshader) return true;
-    
+
     GLint loc;
     if (varname)
        loc = GetUniformLocation(varname);
     else
        loc = index;
 
-    if (loc==-1) 
+    if (loc==-1)
        return false;  // can't find variable / invalid index
-    
+
     glUniform1fv(loc, count, value);
 
     return true;
 }
-bool glShader::setUniform2fv(GLcharARB* varname, GLsizei count, GLfloat *value, GLint index)
+bool glShader::setUniform2fv(const GLcharARB* varname, GLsizei count, GLfloat *value, GLint index)
 {
     if (!useGLSL) return false; // GLSL not available
     if (!_noshader) return true;
-    
+
     GLint loc;
     if (varname)
        loc = GetUniformLocation(varname);
     else
        loc = index;
 
-    if (loc==-1) 
+    if (loc==-1)
        return false;  // can't find variable / invalid index
-    
+
     glUniform2fv(loc, count, value);
 
     return true;
 }
 
-//----------------------------------------------------------------------------- 
+//-----------------------------------------------------------------------------
 
-bool glShader::setUniform3fv(GLcharARB* varname, GLsizei count, GLfloat *value, GLint index)
+bool glShader::setUniform3fv(const GLcharARB* varname, GLsizei count, GLfloat *value, GLint index)
 {
     if (!useGLSL) return false; // GLSL not available
     if (!_noshader) return true;
-    
+
     GLint loc;
     if (varname)
        loc = GetUniformLocation(varname);
     else
        loc = index;
 
-    if (loc==-1) 
+    if (loc==-1)
        return false;  // can't find variable / invalid index
-    
+
     glUniform3fv(loc, count, value);
 
     return true;
 }
 
-//----------------------------------------------------------------------------- 
+//-----------------------------------------------------------------------------
 
-bool glShader::setUniform4fv(GLcharARB* varname, GLsizei count, GLfloat *value, GLint index)
+bool glShader::setUniform4fv(const GLcharARB* varname, GLsizei count, GLfloat *value, GLint index)
 {
     if (!useGLSL) return false; // GLSL not available
     if (!_noshader) return true;
-    
+
     GLint loc;
     if (varname)
        loc = GetUniformLocation(varname);
     else
        loc = index;
 
-    if (loc==-1) 
+    if (loc==-1)
        return false;  // can't find variable / invalid index
-    
+
     glUniform4fv(loc, count, value);
 
     return true;
 }
 
-//----------------------------------------------------------------------------- 
+//-----------------------------------------------------------------------------
 
-bool glShader::setUniform1iv(GLcharARB* varname, GLsizei count, GLint *value, GLint index)
+bool glShader::setUniform1iv(const GLcharARB* varname, GLsizei count, GLint *value, GLint index)
 {
     if (!useGLSL) return false; // GLSL not available
     if (!_noshader) return true;
-    
+
     GLint loc;
     if (varname)
        loc = GetUniformLocation(varname);
     else
        loc = index;
 
-    if (loc==-1) 
+    if (loc==-1)
        return false;  // can't find variable / invalid index
-    
+
     glUniform1iv(loc, count, value);
 
     return true;
 }
 
-//----------------------------------------------------------------------------- 
+//-----------------------------------------------------------------------------
 
-bool glShader::setUniform2iv(GLcharARB* varname, GLsizei count, GLint *value, GLint index)
+bool glShader::setUniform2iv(const GLcharARB* varname, GLsizei count, GLint *value, GLint index)
 {
     if (!useGLSL) return false; // GLSL not available
     if (!_noshader) return true;
-    
+
     GLint loc;
     if (varname)
        loc = GetUniformLocation(varname);
     else
        loc = index;
 
-    if (loc==-1) 
+    if (loc==-1)
        return false;  // can't find variable / invalid index
-    
+
     glUniform2iv(loc, count, value);
 
     return true;
 }
 
-//----------------------------------------------------------------------------- 
+//-----------------------------------------------------------------------------
 
-bool glShader::setUniform3iv(GLcharARB* varname, GLsizei count, GLint *value, GLint index)
+bool glShader::setUniform3iv(const GLcharARB* varname, GLsizei count, GLint *value, GLint index)
 {
     if (!useGLSL) return false; // GLSL not available
     if (!_noshader) return true;
-    
+
     GLint loc;
     if (varname)
        loc = GetUniformLocation(varname);
     else
        loc = index;
 
-    if (loc==-1) 
+    if (loc==-1)
        return false;  // can't find variable / invalid index
-    
+
     glUniform3iv(loc, count, value);
 
     return true;
 }
 
-//----------------------------------------------------------------------------- 
+//-----------------------------------------------------------------------------
 
-bool glShader::setUniform4iv(GLcharARB* varname, GLsizei count, GLint *value, GLint index)
+bool glShader::setUniform4iv(const GLcharARB* varname, GLsizei count, GLint *value, GLint index)
 {
     if (!useGLSL) return false; // GLSL not available
     if (!_noshader) return true;
-    
+
     GLint loc;
     if (varname)
        loc = GetUniformLocation(varname);
     else
        loc = index;
 
-    if (loc==-1) 
+    if (loc==-1)
        return false;  // can't find variable / invalid index
-    
+
     glUniform4iv(loc, count, value);
 
     return true;
 }
 
-//----------------------------------------------------------------------------- 
+//-----------------------------------------------------------------------------
 
-bool glShader::setUniform1uiv(GLcharARB* varname, GLsizei count, GLuint *value, GLint index)
+bool glShader::setUniform1uiv(const GLcharARB* varname, GLsizei count, GLuint *value, GLint index)
 {
     if (!useGLSL) return false; // GLSL not available
     if (!bGPUShader4) return false;
     if (!_noshader) return true;
-    
+
     GLint loc;
     if (varname)
        loc = GetUniformLocation(varname);
     else
        loc = index;
 
-    if (loc==-1) 
+    if (loc==-1)
        return false;  // can't find variable / invalid index
-    
+
     glUniform1uivEXT(loc, count, value);
 
     return true;
 }
 
-//----------------------------------------------------------------------------- 
+//-----------------------------------------------------------------------------
 
-bool glShader::setUniform2uiv(GLcharARB* varname, GLsizei count, GLuint *value, GLint index)
+bool glShader::setUniform2uiv(const GLcharARB* varname, GLsizei count, GLuint *value, GLint index)
 {
     if (!useGLSL) return false; // GLSL not available
     if (!bGPUShader4) return false;
     if (!_noshader) return true;
-    
+
     GLint loc;
     if (varname)
        loc = GetUniformLocation(varname);
     else
        loc = index;
 
-    if (loc==-1) 
+    if (loc==-1)
        return false;  // can't find variable / invalid index
-    
+
     glUniform2uivEXT(loc, count, value);
 
     return true;
 }
 
-//----------------------------------------------------------------------------- 
+//-----------------------------------------------------------------------------
 
-bool glShader::setUniform3uiv(GLcharARB* varname, GLsizei count, GLuint *value, GLint index)
+bool glShader::setUniform3uiv(const GLcharARB* varname, GLsizei count, GLuint *value, GLint index)
 {
     if (!useGLSL) return false; // GLSL not available
     if (!bGPUShader4) return false;
     if (!_noshader) return true;
-    
+
     GLint loc;
     if (varname)
        loc = GetUniformLocation(varname);
     else
        loc = index;
 
-    if (loc==-1) 
+    if (loc==-1)
        return false;  // can't find variable / invalid index
-    
+
     glUniform3uivEXT(loc, count, value);
 
     return true;
 }
 
-//----------------------------------------------------------------------------- 
+//-----------------------------------------------------------------------------
 
-bool glShader::setUniform4uiv(GLcharARB* varname, GLsizei count, GLuint *value, GLint index)
+bool glShader::setUniform4uiv(const GLcharARB* varname, GLsizei count, GLuint *value, GLint index)
 {
     if (!useGLSL) return false; // GLSL not available
     if (!bGPUShader4) return false;
     if (!_noshader) return true;
-    
+
     GLint loc;
     if (varname)
        loc = GetUniformLocation(varname);
     else
        loc = index;
 
-    if (loc==-1) 
+    if (loc==-1)
        return false;  // can't find variable / invalid index
-    
+
     glUniform4uivEXT(loc, count, value);
 
     return true;
 }
 
-//----------------------------------------------------------------------------- 
+//-----------------------------------------------------------------------------
 
-bool glShader::setUniformMatrix2fv(GLcharARB* varname, GLsizei count, GLboolean transpose, GLfloat *value, GLint index)
+bool glShader::setUniformMatrix2fv(const GLcharARB* varname, GLsizei count, GLboolean transpose, GLfloat *value, GLint index)
 {
     if (!useGLSL) return false; // GLSL not available
     if (!_noshader) return true;
-    
+
     GLint loc;
     if (varname)
        loc = GetUniformLocation(varname);
     else
        loc = index;
 
-    if (loc==-1) 
+    if (loc==-1)
        return false;  // can't find variable / invalid index
-    
+
     glUniformMatrix2fv(loc, count, transpose, value);
 
     return true;
 }
 
-//----------------------------------------------------------------------------- 
+//-----------------------------------------------------------------------------
 
-bool glShader::setUniformMatrix3fv(GLcharARB* varname, GLsizei count, GLboolean transpose, GLfloat *value, GLint index)
+bool glShader::setUniformMatrix3fv(const GLcharARB* varname, GLsizei count, GLboolean transpose, GLfloat *value, GLint index)
 {
     if (!useGLSL) return false; // GLSL not available
     if (!_noshader) return true;
-    
+
     GLint loc;
     if (varname)
        loc = GetUniformLocation(varname);
     else
        loc = index;
 
-    if (loc==-1) 
+    if (loc==-1)
        return false;  // can't find variable / invalid index
-    
+
     glUniformMatrix3fv(loc, count, transpose, value);
 
     return true;
 }
 
-//----------------------------------------------------------------------------- 
+//-----------------------------------------------------------------------------
 
-bool glShader::setUniformMatrix4fv(GLcharARB* varname, GLsizei count, GLboolean transpose, GLfloat *value, GLint index)
+bool glShader::setUniformMatrix4fv(const GLcharARB* varname, GLsizei count, GLboolean transpose, GLfloat *value, GLint index)
 {
     if (!useGLSL) return false; // GLSL not available
     if (!_noshader) return true;
-    
+
     GLint loc;
     if (varname)
        loc = GetUniformLocation(varname);
     else
        loc = index;
 
-    if (loc==-1) 
+    if (loc==-1)
        return false;  // can't find variable / invalid index
-    
+
     glUniformMatrix4fv(loc, count, transpose, value);
 
     return true;
 }
 
-//----------------------------------------------------------------------------- 
+//-----------------------------------------------------------------------------
 
 GLint glShader::GetUniformLocation(const GLcharARB *name)
 {
 	GLint loc;
 
 	loc = glGetUniformLocation(ProgramObject, name);
-	if (loc == -1) 
+	if (loc == -1)
 	{
         cout << "Error: can't find uniform variable \"" << name << "\"\n";
 	}
@@ -1013,28 +1013,28 @@ GLint glShader::GetUniformLocation(const GLcharARB *name)
 	return loc;
 }
 
-//----------------------------------------------------------------------------- 
+//-----------------------------------------------------------------------------
 
-void glShader::getUniformfv(GLcharARB* varname, GLfloat* values, GLint index)
+void glShader::getUniformfv(const GLcharARB* varname, GLfloat* values, GLint index)
 {
 if (!useGLSL) return;
- 
+
     GLint loc;
     if (varname)
        loc = GetUniformLocation(varname);
     else
        loc = index;
 
-    if (loc==-1) 
+    if (loc==-1)
        return;  // can't find variable / invalid index
 
 	glGetUniformfv(ProgramObject, loc, values);
-	
+
 }
 
-//----------------------------------------------------------------------------- 
+//-----------------------------------------------------------------------------
 
-void glShader::getUniformiv(GLcharARB* varname, GLint* values, GLint index)
+void glShader::getUniformiv(const GLcharARB* varname, GLint* values, GLint index)
 {
     if (!useGLSL) return;
 
@@ -1044,16 +1044,16 @@ void glShader::getUniformiv(GLcharARB* varname, GLint* values, GLint index)
     else
        loc = index;
 
-    if (loc==-1) 
+    if (loc==-1)
        return;  // can't find variable / invalid index
-	
+
 	glGetUniformiv(ProgramObject, loc, values);
 
 }
 
-//----------------------------------------------------------------------------- 
+//-----------------------------------------------------------------------------
 
-void glShader::getUniformuiv(GLcharARB* varname, GLuint* values, GLint index)
+void glShader::getUniformuiv(const GLcharARB* varname, GLuint* values, GLint index)
 {
     if (!useGLSL) return;
 
@@ -1063,9 +1063,9 @@ void glShader::getUniformuiv(GLcharARB* varname, GLuint* values, GLint index)
     else
        loc = index;
 
-    if (loc==-1) 
+    if (loc==-1)
        return;  // can't find variable / invalid index
-	
+
 	glGetUniformuivEXT(ProgramObject, loc, values);
 
 }
@@ -1360,7 +1360,7 @@ unsigned long getFileLength(ifstream& file)
 
 
 //----------------------------------------------------------------------------- 
-int glShaderObject::load(char* filename)
+int glShaderObject::load(const char* filename)
 {
    ifstream file;
 	file.open(filename, ios::in);
@@ -1413,7 +1413,7 @@ void glShaderObject::loadFromMemory(const char* program)
 
 // ----------------------------------------------------------------------------
 // Compiler Log: Ausgabe der Compiler Meldungen in String
-char* glShaderObject::getCompilerLog(void)
+const char* glShaderObject::getCompilerLog(void)
 {    
 if (!useGLSL) return aGLSLStrings[0];
  
@@ -1578,7 +1578,7 @@ void glShaderManager::SetVerticesOut(int nVerticesOut)
 }
 
 // ----------------------------------------------------------------------------
-glShader* glShaderManager::loadfromFile(char* vertexFile, char* fragmentFile) 
+glShader* glShaderManager::loadfromFile(const char* vertexFile, const char* fragmentFile)
 {
 	// Shader logs
 	ofstream vertexLogFile;
@@ -1688,7 +1688,7 @@ glShader* glShaderManager::loadfromFile(char* vertexFile, char* fragmentFile)
 }
 
 
-glShader* glShaderManager::loadfromFile(char* vertexFile, char* geometryFile, char* fragmentFile)
+glShader* glShaderManager::loadfromFile(const char* vertexFile, const char* geometryFile, const char* fragmentFile)
 {
    glShader* o = new glShader();
    o->UsesGeometryShader(true);

--- a/source/Renderer/glsl.h
+++ b/source/Renderer/glsl.h
@@ -63,11 +63,11 @@ Make sure to check extension "GL_EXT_geometry_shader4" before using Geometry sha
                   glShaderObject();
       virtual     ~glShaderObject();
         
-      int         load(char* filename);                     //!< \brief Loads a shader file. \param filename The name of the ASCII file containing the shader. \return returns 0 if everything is ok.\n -1: File not found\n -2: Empty File\n -3: no memory
+      int         load(const char* filename);                     //!< \brief Loads a shader file. \param filename The name of the ASCII file containing the shader. \return returns 0 if everything is ok.\n -1: File not found\n -2: Empty File\n -3: no memory
       void        loadFromMemory(const char* program);      //!< \brief Load program from null-terminated char array. \param program Address of the memory containing the shader program.
        
       bool        compile(void);                            //!< compile program
-      char*       getCompilerLog(void);                     //!< get compiler messages
+      const char* getCompilerLog(void);                     //!< get compiler messages
       GLint       getAttribLocation(char* attribName);      //!< \brief Retrieve attribute location. \return Returns attribute location. \param attribName Specify attribute name.  
     
    protected:
@@ -129,62 +129,62 @@ Make sure to check extension "GL_EXT_geometry_shader4" before using Geometry sha
       GLuint     GetProgramObject(){return ProgramObject;}
 
       bool       link(void);                        //!< Link all Shaders
-      char*      getLinkerLog(void);                //!< Get Linker Messages \return char pointer to linker messages. Memory of this string is available until you link again or destroy this class.
+      const char* getLinkerLog(void);                //!< Get Linker Messages \return char pointer to linker messages. Memory of this string is available until you link again or destroy this class.
 
       void       begin();                           //!< use Shader. OpenGL calls will go through vertex, geometry and/or fragment shaders.
       void       end();                             //!< Stop using this shader. OpenGL calls will go through regular pipeline.
-      
+
       // Geometry Shader: Input Type, Output and Number of Vertices out
       void       SetInputPrimitiveType(int nInputPrimitiveType);   //!< Set the input primitive type for the geometry shader
       void       SetOutputPrimitiveType(int nOutputPrimitiveType); //!< Set the output primitive type for the geometry shader
       void       SetVerticesOut(int nVerticesOut);                 //!< Set the maximal number of vertices the geometry shader can output
-     
+
       GLint       GetUniformLocation(const GLcharARB *name);  //!< Retrieve Location (index) of a Uniform Variable
 
       // Submitting Uniform Variables. You can set varname to 0 and specifiy index retrieved with GetUniformLocation (best performance)
-      bool       setUniform1f(GLcharARB* varname, GLfloat v0, GLint index = -1);  //!< Specify value of uniform variable. \param varname The name of the uniform variable.
-      bool       setUniform2f(GLcharARB* varname, GLfloat v0, GLfloat v1, GLint index = -1);  //!< Specify value of uniform variable. \param varname The name of the uniform variable.
-      bool       setUniform3f(GLcharARB* varname, GLfloat v0, GLfloat v1, GLfloat v2, GLint index = -1);  //!< Specify value of uniform variable. \param varname The name of the uniform variable.
-      bool       setUniform4f(GLcharARB* varname, GLfloat v0, GLfloat v1, GLfloat v2, GLfloat v3, GLint index = -1);  //!< Specify value of uniform variable. \param varname The name of the uniform variable.
+      bool       setUniform1f(const GLcharARB* varname, GLfloat v0, GLint index = -1);  //!< Specify value of uniform variable. \param varname The name of the uniform variable.
+      bool       setUniform2f(const GLcharARB* varname, GLfloat v0, GLfloat v1, GLint index = -1);  //!< Specify value of uniform variable. \param varname The name of the uniform variable.
+      bool       setUniform3f(const GLcharARB* varname, GLfloat v0, GLfloat v1, GLfloat v2, GLint index = -1);  //!< Specify value of uniform variable. \param varname The name of the uniform variable.
+      bool       setUniform4f(const GLcharARB* varname, GLfloat v0, GLfloat v1, GLfloat v2, GLfloat v3, GLint index = -1);  //!< Specify value of uniform variable. \param varname The name of the uniform variable.
 
-      bool       setUniform1i(GLcharARB* varname, GLint v0, GLint index = -1);  //!< Specify value of uniform integer variable. \param varname The name of the uniform variable.
-      bool       setUniform2i(GLcharARB* varname, GLint v0, GLint v1, GLint index = -1); //!< Specify value of uniform integer variable. \param varname The name of the uniform variable.
-      bool       setUniform3i(GLcharARB* varname, GLint v0, GLint v1, GLint v2, GLint index = -1); //!< Specify value of uniform integer variable. \param varname The name of the uniform variable.
-      bool       setUniform4i(GLcharARB* varname, GLint v0, GLint v1, GLint v2, GLint v3, GLint index = -1); //!< Specify value of uniform integer variable. \param varname The name of the uniform variable.
+      bool       setUniform1i(const GLcharARB* varname, GLint v0, GLint index = -1);  //!< Specify value of uniform integer variable. \param varname The name of the uniform variable.
+      bool       setUniform2i(const GLcharARB* varname, GLint v0, GLint v1, GLint index = -1); //!< Specify value of uniform integer variable. \param varname The name of the uniform variable.
+      bool       setUniform3i(const GLcharARB* varname, GLint v0, GLint v1, GLint v2, GLint index = -1); //!< Specify value of uniform integer variable. \param varname The name of the uniform variable.
+      bool       setUniform4i(const GLcharARB* varname, GLint v0, GLint v1, GLint v2, GLint v3, GLint index = -1); //!< Specify value of uniform integer variable. \param varname The name of the uniform variable.
 
       // Note: unsigned integers require GL_EXT_gpu_shader4 (for example GeForce 8800)
-      bool       setUniform1ui(GLcharARB* varname, GLuint v0, GLint index = -1); //!< Specify value of uniform unsigned integer variable. \warning Requires GL_EXT_gpu_shader4. \param varname The name of the uniform variable.
-      bool       setUniform2ui(GLcharARB* varname, GLuint v0, GLuint v1, GLint index = -1); //!< Specify value of uniform unsigned integer variable. \warning Requires GL_EXT_gpu_shader4. \param varname The name of the uniform variable.
-      bool       setUniform3ui(GLcharARB* varname, GLuint v0, GLuint v1, GLuint v2, GLint index = -1); //!< Specify value of uniform unsigned integer variable. \warning Requires GL_EXT_gpu_shader4. \param varname The name of the uniform variable.
-      bool       setUniform4ui(GLcharARB* varname, GLuint v0, GLuint v1, GLuint v2, GLuint v3, GLint index = -1); //!< Specify value of uniform unsigned integer variable. \warning Requires GL_EXT_gpu_shader4. \param varname The name of the uniform variable.
+      bool       setUniform1ui(const GLcharARB* varname, GLuint v0, GLint index = -1); //!< Specify value of uniform unsigned integer variable. \warning Requires GL_EXT_gpu_shader4. \param varname The name of the uniform variable.
+      bool       setUniform2ui(const GLcharARB* varname, GLuint v0, GLuint v1, GLint index = -1); //!< Specify value of uniform unsigned integer variable. \warning Requires GL_EXT_gpu_shader4. \param varname The name of the uniform variable.
+      bool       setUniform3ui(const GLcharARB* varname, GLuint v0, GLuint v1, GLuint v2, GLint index = -1); //!< Specify value of uniform unsigned integer variable. \warning Requires GL_EXT_gpu_shader4. \param varname The name of the uniform variable.
+      bool       setUniform4ui(const GLcharARB* varname, GLuint v0, GLuint v1, GLuint v2, GLuint v3, GLint index = -1); //!< Specify value of uniform unsigned integer variable. \warning Requires GL_EXT_gpu_shader4. \param varname The name of the uniform variable.
 
       // Arrays
-      bool       setUniform1fv(GLcharARB* varname, GLsizei count, GLfloat *value, GLint index = -1); //!< Specify values of uniform array. \param varname The name of the uniform variable.
-      bool       setUniform2fv(GLcharARB* varname, GLsizei count, GLfloat *value, GLint index = -1); //!< Specify values of uniform array. \param varname The name of the uniform variable.
-      bool       setUniform3fv(GLcharARB* varname, GLsizei count, GLfloat *value, GLint index = -1); //!< Specify values of uniform array. \param varname The name of the uniform variable.
-      bool       setUniform4fv(GLcharARB* varname, GLsizei count, GLfloat *value, GLint index = -1); //!< Specify values of uniform array. \param varname The name of the uniform variable.
-      
-      bool       setUniform1iv(GLcharARB* varname, GLsizei count, GLint *value, GLint index = -1); //!< Specify values of uniform array. \param varname The name of the uniform variable.
-      bool       setUniform2iv(GLcharARB* varname, GLsizei count, GLint *value, GLint index = -1); //!< Specify values of uniform array. \param varname The name of the uniform variable.
-      bool       setUniform3iv(GLcharARB* varname, GLsizei count, GLint *value, GLint index = -1); //!< Specify values of uniform array. \param varname The name of the uniform variable.
-      bool       setUniform4iv(GLcharARB* varname, GLsizei count, GLint *value, GLint index = -1); //!< Specify values of uniform array. \param varname The name of the uniform variable.
-      
-      bool       setUniform1uiv(GLcharARB* varname, GLsizei count, GLuint *value, GLint index = -1); //!< Specify values of uniform array. \warning Requires GL_EXT_gpu_shader4. \param varname The name of the uniform variable.
-      bool       setUniform2uiv(GLcharARB* varname, GLsizei count, GLuint *value, GLint index = -1); //!< Specify values of uniform array. \warning Requires GL_EXT_gpu_shader4. \param varname The name of the uniform variable.
-      bool       setUniform3uiv(GLcharARB* varname, GLsizei count, GLuint *value, GLint index = -1); //!< Specify values of uniform array. \warning Requires GL_EXT_gpu_shader4. \param varname The name of the uniform variable.
-      bool       setUniform4uiv(GLcharARB* varname, GLsizei count, GLuint *value, GLint index = -1); //!< Specify values of uniform array. \warning Requires GL_EXT_gpu_shader4. \param varname The name of the uniform variable.
-      
-      bool       setUniformMatrix2fv(GLcharARB* varname, GLsizei count, GLboolean transpose, GLfloat *value, GLint index = -1); //!< Specify values of uniform 2x2 matrix. \param varname The name of the uniform variable.
-      bool       setUniformMatrix3fv(GLcharARB* varname, GLsizei count, GLboolean transpose, GLfloat *value, GLint index = -1); //!< Specify values of uniform 3x3 matrix. \param varname The name of the uniform variable.
-      bool       setUniformMatrix4fv(GLcharARB* varname, GLsizei count, GLboolean transpose, GLfloat *value, GLint index = -1); //!< Specify values of uniform 4x4 matrix. \param varname The name of the uniform variable.
- 
+      bool       setUniform1fv(const GLcharARB* varname, GLsizei count, GLfloat *value, GLint index = -1); //!< Specify values of uniform array. \param varname The name of the uniform variable.
+      bool       setUniform2fv(const GLcharARB* varname, GLsizei count, GLfloat *value, GLint index = -1); //!< Specify values of uniform array. \param varname The name of the uniform variable.
+      bool       setUniform3fv(const GLcharARB* varname, GLsizei count, GLfloat *value, GLint index = -1); //!< Specify values of uniform array. \param varname The name of the uniform variable.
+      bool       setUniform4fv(const GLcharARB* varname, GLsizei count, GLfloat *value, GLint index = -1); //!< Specify values of uniform array. \param varname The name of the uniform variable.
+
+      bool       setUniform1iv(const GLcharARB* varname, GLsizei count, GLint *value, GLint index = -1); //!< Specify values of uniform array. \param varname The name of the uniform variable.
+      bool       setUniform2iv(const GLcharARB* varname, GLsizei count, GLint *value, GLint index = -1); //!< Specify values of uniform array. \param varname The name of the uniform variable.
+      bool       setUniform3iv(const GLcharARB* varname, GLsizei count, GLint *value, GLint index = -1); //!< Specify values of uniform array. \param varname The name of the uniform variable.
+      bool       setUniform4iv(const GLcharARB* varname, GLsizei count, GLint *value, GLint index = -1); //!< Specify values of uniform array. \param varname The name of the uniform variable.
+
+      bool       setUniform1uiv(const GLcharARB* varname, GLsizei count, GLuint *value, GLint index = -1); //!< Specify values of uniform array. \warning Requires GL_EXT_gpu_shader4. \param varname The name of the uniform variable.
+      bool       setUniform2uiv(const GLcharARB* varname, GLsizei count, GLuint *value, GLint index = -1); //!< Specify values of uniform array. \warning Requires GL_EXT_gpu_shader4. \param varname The name of the uniform variable.
+      bool       setUniform3uiv(const GLcharARB* varname, GLsizei count, GLuint *value, GLint index = -1); //!< Specify values of uniform array. \warning Requires GL_EXT_gpu_shader4. \param varname The name of the uniform variable.
+      bool       setUniform4uiv(const GLcharARB* varname, GLsizei count, GLuint *value, GLint index = -1); //!< Specify values of uniform array. \warning Requires GL_EXT_gpu_shader4. \param varname The name of the uniform variable.
+
+      bool       setUniformMatrix2fv(const GLcharARB* varname, GLsizei count, GLboolean transpose, GLfloat *value, GLint index = -1); //!< Specify values of uniform 2x2 matrix. \param varname The name of the uniform variable.
+      bool       setUniformMatrix3fv(const GLcharARB* varname, GLsizei count, GLboolean transpose, GLfloat *value, GLint index = -1); //!< Specify values of uniform 3x3 matrix. \param varname The name of the uniform variable.
+      bool       setUniformMatrix4fv(const GLcharARB* varname, GLsizei count, GLboolean transpose, GLfloat *value, GLint index = -1); //!< Specify values of uniform 4x4 matrix. \param varname The name of the uniform variable.
+
       // Receive Uniform variables:
-      void       getUniformfv(GLcharARB* varname, GLfloat* values, GLint index = -1); //!< Receive value of uniform variable. \param varname The name of the uniform variable.
-      void       getUniformiv(GLcharARB* varname, GLint* values, GLint index = -1); //!< Receive value of uniform variable. \param varname The name of the uniform variable.
-      void       getUniformuiv(GLcharARB* varname, GLuint* values, GLint index = -1); //!< Receive value of uniform variable. \warning Requires GL_EXT_gpu_shader4 \param varname The name of the uniform variable.
+      void       getUniformfv(const GLcharARB* varname, GLfloat* values, GLint index = -1); //!< Receive value of uniform variable. \param varname The name of the uniform variable.
+      void       getUniformiv(const GLcharARB* varname, GLint* values, GLint index = -1); //!< Receive value of uniform variable. \param varname The name of the uniform variable.
+      void       getUniformuiv(const GLcharARB* varname, GLuint* values, GLint index = -1); //!< Receive value of uniform variable. \warning Requires GL_EXT_gpu_shader4 \param varname The name of the uniform variable.
 
       /*! This method simply calls glBindAttribLocation for the current ProgramObject
-      \warning NVidia implementation is different than the GLSL standard: GLSL attempts to eliminate aliasing of vertex attributes but this is integral to NVIDIA’s hardware approach and necessary for maintaining compatibility with existing OpenGL applications that NVIDIA customers rely on. NVIDIA’s GLSL implementation therefore does not allow built-in vertex attributes to collide with a generic vertex attributes that is assigned to a particular vertex  attribute index with glBindAttribLocation. For example, you should not use gl_Normal (a built-in vertex attribute) and also use glBindAttribLocation to bind a generic vertex attribute named "whatever" to vertex attribute index 2 because gl_Normal aliases to index 2.
+      \warning NVidia implementation is different than the GLSL standard: GLSL attempts to eliminate aliasing of vertex attributes but this is integral to NVIDIAï¿½s hardware approach and necessary for maintaining compatibility with existing OpenGL applications that NVIDIA customers rely on. NVIDIAï¿½s GLSL implementation therefore does not allow built-in vertex attributes to collide with a generic vertex attributes that is assigned to a particular vertex  attribute index with glBindAttribLocation. For example, you should not use gl_Normal (a built-in vertex attribute) and also use glBindAttribLocation to bind a generic vertex attribute named "whatever" to vertex attribute index 2 because gl_Normal aliases to index 2.
       \verbatim
       gl_Vertex                0
       gl_Normal                2
@@ -284,13 +284,13 @@ Make sure to check extension "GL_EXT_geometry_shader4" before using Geometry sha
        virtual ~glShaderManager();
 
        // Regular GLSL (Vertex+Fragment Shader)
-       glShader* loadfromFile(char* vertexFile, char* fragmentFile);    //!< load vertex/fragment shader from file. If you specify 0 for one of the shaders, the fixed function pipeline is used for that part. \param vertexFile Vertex Shader File. \param fragmentFile Fragment Shader File.
+       glShader* loadfromFile(const char* vertexFile, const char* fragmentFile);    //!< load vertex/fragment shader from file. If you specify 0 for one of the shaders, the fixed function pipeline is used for that part. \param vertexFile Vertex Shader File. \param fragmentFile Fragment Shader File.
        glShader* loadfromMemory(const char* vertexMem, const char* fragmentMem); //!< load vertex/fragment shader from memory. If you specify 0 for one of the shaders, the fixed function pipeline is used for that part.
-       
+
        // With Geometry Shader (Vertex+Geomentry+Fragment Shader)
-       glShader* loadfromFile(char* vertexFile, char* geometryFile, char* fragmentFile); //!< load vertex/geometry/fragment shader from file. If you specify 0 for one of the shaders, the fixed function pipeline is used for that part. \param vertexFile Vertex Shader File. \param geometryFile Geometry Shader File \param fragmentFile Fragment Shader File.
+       glShader* loadfromFile(const char* vertexFile, const char* geometryFile, const char* fragmentFile); //!< load vertex/geometry/fragment shader from file. If you specify 0 for one of the shaders, the fixed function pipeline is used for that part. \param vertexFile Vertex Shader File. \param geometryFile Geometry Shader File \param fragmentFile Fragment Shader File.
        glShader* loadfromMemory(const char* vertexMem, const char* geometryMem, const char* fragmentMem); //!< load vertex/geometry/fragment shader from memory. If you specify 0 for one of the shaders, the fixed function pipeline is used for that part.
-       
+
        void      SetInputPrimitiveType(int nInputPrimitiveType);    //!< Set the input primitive type for the geometry shader \param nInputPrimitiveType Input Primitive Type, for example GL_TRIANGLES
        void      SetOutputPrimitiveType(int nOutputPrimitiveType);  //!< Set the output primitive type for the geometry shader \param nOutputPrimitiveType Output Primitive Type, for example GL_TRIANGLE_STRIP
        void      SetVerticesOut(int nVerticesOut);                  //!< Set the maximal number of vertices the geometry shader can output \param nVerticesOut Maximal number of output vertices. It is possible to output less vertices!

--- a/source/utils/FileUtils.cpp
+++ b/source/utils/FileUtils.cpp
@@ -37,7 +37,7 @@ string wchar_t2string(const wchar_t *wchar)
 
 wchar_t *string2wchar_t(const string &str)
 {
-	wchar_t wchar[260];
+	static wchar_t wchar[260];
 	unsigned int index = 0;
 	while(index < str.size())
 	{


### PR DESCRIPTION
These warnings were seen when building on linux.  The warnings are:
- conversion from const char * to char *
- integer to * of different size
- passing ptr to non-ptr arg
- returning address of local variable